### PR TITLE
Fix: upfirdn2d_plugin compilation issue.

### DIFF
--- a/configs/main.yml
+++ b/configs/main.yml
@@ -2,7 +2,7 @@ env:
   python_bin: "python" # Path to the python bin
   base_project_dir: ${hydra:runtime.cwd}
   before_train_commands: []
-  torch_extensions_dir: "/tmp/torch_extensions"
+  torch_extensions_dir: "~/.cache/torch_extensions"
   data_dir: "data"
   objects_to_copy:
     - ${env.base_project_dir}/configs


### PR DESCRIPTION
Solve permission issue of `upfirdn2d_plugin` compilation. 
See https://github.com/NVlabs/stylegan2-ada-pytorch/issues/39 and https://github.com/pytorch/pytorch/commit/13013848d58a606da7377affeb416affb65f4a8a .